### PR TITLE
Added AppConfig (improves Django 1.8 compatibility)

### DIFF
--- a/mailqueue/__init__.py
+++ b/mailqueue/__init__.py
@@ -13,6 +13,7 @@ from mailqueue.utils import render_letter
 
 logger = logging.getLogger('mailqueue')
 
+default_app_config = 'mailqueue.app.MailQueueConfig'
 
 def add_templated_mail(
     to_email,

--- a/mailqueue/app.py
+++ b/mailqueue/app.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class MailQueueConfig(AppConfig):
+    name = 'mailqueue'
+    verbose_name = "Django Mail Queue"

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     url='https://github.com/shantilabs/django-mailqueue',
     packages=[
         'mailqueue',
+        'mailqueue.migrations',
     ],
     package_data={
         'mailqueue': ['templates/*'],


### PR DESCRIPTION
Fixes this warning (I do have 'mailqueue' in INSTALLED_APPS):

```
2015-07-23 17:47:12,028 10952 WARNING base: /home/zed/.virtualenvs/wb4/local/lib/python2.7/site-packages/mailqueue/models.py:13: RemovedInDjango19Warning: Model class mailqueue.models.MailerMessage doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
```

Also, migrations don't work without AppConfig.
