### PR TITLE
Django 1.9 compatibility changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Cases:
 ```python
 from datetime import timedelta 
 from django.utils import timezone
-import mailqueue
+from mailqueue import mailqueue
 
 # simple email
 mailqueue.add_mail('subject', 'message', 'email@example.com')
@@ -65,7 +65,7 @@ Django templates for letters
 
 Usage:
 ```python
-import mailqueue
+from mailqueue import mailqueue
 
 # email from django templates
 mailqueue.add_templated_mail(customer.email, 'letters/hello.txt', {

--- a/mailqueue/__init__.py
+++ b/mailqueue/__init__.py
@@ -1,138 +1,36 @@
 import logging
-import time
-import datetime
-
-from django.conf import settings
-from django.utils import timezone
-from django.core.files.base import ContentFile
-
-from mailqueue import conf
-from mailqueue.models import MailerMessage
-from mailqueue.utils import render_letter
 
 
 logger = logging.getLogger('mailqueue')
 
 default_app_config = 'mailqueue.app.MailQueueConfig'
 
-def add_templated_mail(
-    to_email,
-    template,
-    context=None,
-    **kwargs
-):
-    subj, body = render_letter(template, context)
-    return add_mail(subj, body, to_email, **kwargs)
+
+def add_templated_mail(*args, **kwargs):
+    logger.warning("Deprecated call to mailqueue.add_templated_mail. Recommended way to import mailqueue: from mailqueue import mailqueue; mailqueue.add_templated_mail(...)")
+    import mailqueue.mailqueue
+    return mailqueue.mailqueue.add_templated_mail(*args, **kwargs)
 
 
-def add_mail(
-    subj,
-    body,
-    to_email,
-    from_email=None,
-    reply_to=None,
-    html_body='',
-    start_datetime=None,
-    send_now=False,
-    attach=None,
-):
-    """
-    Base letter.
-    """
-    logger.info(u'add letter to %s with subject = %r', to_email, subj)
-
-    if send_now or not start_datetime:
-        start_datetime = timezone.now()
-
-    if isinstance(to_email, basestring):
-        to_email = [to_email]
-
-    for t in to_email:
-        obj = MailerMessage.objects.create(
-            subject=subj,
-            message=body,
-            html_message=html_body,
-            from_email=from_email,
-            to_email=t,
-            reply_to=reply_to,
-            start_datetime=start_datetime,
-        )
-
-        if attach:
-            assert isinstance(attach, ContentFile)
-            obj.attach.save(attach.name, attach)
-
-        if send_now or (
-            conf.MAILQUEUE_SEND_METHOD == 'now' and
-            obj.start_datetime <= timezone.now()
-        ):
-            logger.info(u'send letter #%d now', obj.id)
-            obj.send()
-        elif conf.MAILQUEUE_SEND_METHOD == 'celery':
-            logger.info(u'send letter #%d via celery', obj.id)
-            from mailqueue.tasks import process_mailqueue
-            process_mailqueue.delay()
-        else:
-            logger.info(u'send letter #%d later', obj.id)
+def add_mail(*args, **kwargs):
+    logger.warning("Deprecated call to mailqueue.add_mail. Recommended way to import mailqueue: from mailqueue import mailqueue; mailqueue.add_mail(...)")
+    import mailqueue.mailqueue
+    return mailqueue.mailqueue.add_mail(*args, **kwargs)
 
 
-def add_glued(
-    subj,
-    body,
-    from_email=None,
-    to_email=[x[1] for x in settings.ADMINS],
-    delay_hours=1,
-):
-    """
-    Autoconcatenated debug letters.
-    """
-    if isinstance(to_email, basestring):
-        to_email = [to_email]
-    for t in to_email:
-        obj, created = MailerMessage.objects.get_or_create(
-            subject=subj,
-            from_email=from_email,
-            to_email=t,
-            sent_datetime__isnull=True,
-            defaults=dict(
-                message=body,
-                start_datetime=timezone.now() + datetime.timedelta(delay_hours),
-            ),
-        )
-        if not created:
-            obj.message += '\n' + body
-            obj.save()
+def add_glued(*args, **kwargs):
+    logger.warning("Deprecated call to mailqueue.add_glued. Recommended way to import mailqueue: from mailqueue import mailqueue; mailqueue.add_glued(...)")
+    import mailqueue.mailqueue
+    return mailqueue.mailqueue.add_glued(*args, **kwargs)
 
 
-def process():
-    """
-    Process mail queue.
-    """
-    logger.info('process...')
-    while True:
-        time.sleep(conf.MAILQUEUE_PROCESSING_PAUSE_SECONDS)
-        messages = MailerMessage.objects.filter(
-            sent_datetime__isnull=True,
-            start_datetime__lte=timezone.now(),
-        )
-        logger.info('%d message(s) in queue..', messages.count())
-        try:
-            messages[0].send()
-        except IndexError:
-            break
-
-    logger.info('...process')
+def process(*args, **kwargs):
+    logger.warning("Deprecated call to mailqueue.process. Recommended way to import mailqueue: from mailqueue import mailqueue; mailqueue.process(...)")
+    import mailqueue.mailqueue
+    return mailqueue.mailqueue.process(*args, **kwargs)
 
 
-def clean():
-    """
-    Clean mail queue.
-    """
-    lifetime_days = conf.MAILQUEUE_ARCHIVE_LIFETIME_DAYS
-    logger.info('clean (lifetime_days=%s)...', lifetime_days)
-    if lifetime_days:
-        deadline = timezone.now() - datetime.timedelta(lifetime_days)
-        messages = MailerMessage.objects.filter(sent_datetime__lte=deadline)
-        logger.info('%d message(s) to delete (deadline=%s)', messages.count(), deadline)
-        messages.delete()
-    logger.info('...clean')
+def clean(*args, **kwargs):
+    logger.warning("Deprecated call to mailqueue.clean. Recommended way to import mailqueue: from mailqueue import mailqueue; mailqueue.clean(...)")
+    import mailqueue.mailqueue
+    return mailqueue.mailqueue.clean(*args, **kwargs)

--- a/mailqueue/admin.py
+++ b/mailqueue/admin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
 from django.contrib import admin
-from mailqueue.models import MailerMessage
+from .models import MailerMessage
 
 
 class MailerMessageAdmin(admin.ModelAdmin):

--- a/mailqueue/conf.py
+++ b/mailqueue/conf.py
@@ -8,7 +8,7 @@ if isinstance(MAILQUEUE_SERVER_SETTINGS, dict):
     MAILQUEUE_SERVER_SETTINGS = [MAILQUEUE_SERVER_SETTINGS]
 
 MAILQUEUE_SEND_METHOD = getattr(settings, 'MAILQUEUE_SEND_METHOD', 'now')
-if not MAILQUEUE_SEND_METHOD in ('now', 'cron', 'celery'):
+if MAILQUEUE_SEND_METHOD not in ('now', 'cron', 'celery'):
     raise ImproperlyConfigured('Incorrect MAILQUEUE_SEND_METHOD value')
 
 MAILQUEUE_ARCHIVE_LIFETIME_DAYS = int(getattr(settings, 'MAILQUEUE_ARCHIVE_LIFETIME_DAYS', 0))

--- a/mailqueue/mailqueue.py
+++ b/mailqueue/mailqueue.py
@@ -1,0 +1,137 @@
+import logging
+import time
+import datetime
+
+from django.conf import settings
+from django.utils import timezone
+from django.core.files.base import ContentFile
+
+from . import conf
+from .models import MailerMessage
+from .utils import render_letter
+
+
+logger = logging.getLogger('mailqueue')
+
+
+def add_templated_mail(
+    to_email,
+    template,
+    context=None,
+    **kwargs
+):
+    subj, body = render_letter(template, context)
+    return add_mail(subj, body, to_email, **kwargs)
+
+
+def add_mail(
+    subj,
+    body,
+    to_email,
+    from_email=None,
+    reply_to=None,
+    html_body='',
+    start_datetime=None,
+    send_now=False,
+    attach=None,
+):
+    """
+    Base letter.
+    """
+    logger.info(u'add letter to %s with subject = %r', to_email, subj)
+
+    if send_now or not start_datetime:
+        start_datetime = timezone.now()
+
+    if isinstance(to_email, basestring):
+        to_email = [to_email]
+
+    for t in to_email:
+        obj = MailerMessage.objects.create(
+            subject=subj,
+            message=body,
+            html_message=html_body,
+            from_email=from_email,
+            to_email=t,
+            reply_to=reply_to,
+            start_datetime=start_datetime,
+        )
+
+        if attach:
+            assert isinstance(attach, ContentFile)
+            obj.attach.save(attach.name, attach)
+
+        if send_now or (
+            conf.MAILQUEUE_SEND_METHOD == 'now' and
+            obj.start_datetime <= timezone.now()
+        ):
+            logger.info(u'send letter #%d now', obj.id)
+            obj.send()
+        elif conf.MAILQUEUE_SEND_METHOD == 'celery':
+            logger.info(u'send letter #%d via celery', obj.id)
+            from mailqueue.tasks import process_mailqueue
+            process_mailqueue.delay()
+        else:
+            logger.info(u'send letter #%d later', obj.id)
+
+
+def add_glued(
+    subj,
+    body,
+    from_email=None,
+    to_email=[x[1] for x in settings.ADMINS],
+    delay_hours=1,
+):
+    """
+    Autoconcatenated debug letters.
+    """
+    if isinstance(to_email, basestring):
+        to_email = [to_email]
+    for t in to_email:
+        obj, created = MailerMessage.objects.get_or_create(
+            subject=subj,
+            from_email=from_email,
+            to_email=t,
+            sent_datetime__isnull=True,
+            defaults=dict(
+                message=body,
+                start_datetime=timezone.now() + datetime.timedelta(delay_hours),
+            ),
+        )
+        if not created:
+            obj.message += '\n' + body
+            obj.save()
+
+
+def process():
+    """
+    Process mail queue.
+    """
+    logger.info('process...')
+    while True:
+        time.sleep(conf.MAILQUEUE_PROCESSING_PAUSE_SECONDS)
+        messages = MailerMessage.objects.filter(
+            sent_datetime__isnull=True,
+            start_datetime__lte=timezone.now(),
+        )
+        logger.info('%d message(s) in queue..', messages.count())
+        try:
+            messages[0].send()
+        except IndexError:
+            break
+
+    logger.info('...process')
+
+
+def clean():
+    """
+    Clean mail queue.
+    """
+    lifetime_days = conf.MAILQUEUE_ARCHIVE_LIFETIME_DAYS
+    logger.info('clean (lifetime_days=%s)...', lifetime_days)
+    if lifetime_days:
+        deadline = timezone.now() - datetime.timedelta(lifetime_days)
+        messages = MailerMessage.objects.filter(sent_datetime__lte=deadline)
+        logger.info('%d message(s) to delete (deadline=%s)', messages.count(), deadline)
+        messages.delete()
+    logger.info('...clean')

--- a/mailqueue/models.py
+++ b/mailqueue/models.py
@@ -6,8 +6,8 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy
 
-from mailqueue import conf
-from mailqueue.utils import clean_email
+from . import conf
+from .utils import clean_email
 
 
 class MailerMessage(models.Model):

--- a/mailqueue/tasks.py
+++ b/mailqueue/tasks.py
@@ -1,6 +1,6 @@
 import logging
 from celery import shared_task
-from mailqueue import process, clean
+from .mailqueue import process, clean
 
 
 logger = logging.getLogger('mailqueue')

--- a/mailqueue/tests/test_email.py
+++ b/mailqueue/tests/test_email.py
@@ -3,9 +3,9 @@ from django.conf import settings
 from django.core import mail
 from django.test.utils import setup_test_environment
 from django.utils import timezone
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 
-from mailqueue import add_templated_mail, MailerMessage, process, add_mail, clean, conf
+from ..mailqueue import add_templated_mail, MailerMessage, process, add_mail, clean, conf
 
 
 class TestEmail(TestCase):


### PR DESCRIPTION
В django 1.9  стало невозможным импортировать и использовать модели до момента, когда приложение сконфигурировано. Поэтому из **init**.py все функции пришлось переместить в модуль mailqueue.py, а на старом месте оставить функции-обертки для обратной совместимости.

В клиентских приложениях импортировать библиотеку придется вот так: `from mailqueue import mailqueue`. Мне это не очень нравится,  но более очевидного имени для нового модуля я не увидел. Как вариант, можно убрать варнинги из функций-оберток и сказать, что это каноничный формат испоьзования.
